### PR TITLE
Fixes issues with concurrent write

### DIFF
--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/UploadSourceTask.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/UploadSourceTask.kt
@@ -4,14 +4,13 @@ import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.source.SourceRecord
 import org.apache.kafka.connect.source.SourceTask
 import org.radarbase.connect.upload.UploadSourceConnectorConfig.Companion.SOURCE_POLL_INTERVAL_CONFIG
-import org.radarbase.connect.upload.api.PollDTO
-import org.radarbase.connect.upload.api.RecordMetadataDTO
-import org.radarbase.connect.upload.api.UploadBackendClient
+import org.radarbase.connect.upload.api.*
 import org.radarbase.connect.upload.converter.Converter
 import org.radarbase.connect.upload.converter.Converter.Companion.END_OF_RECORD_KEY
 import org.radarbase.connect.upload.converter.Converter.Companion.RECORD_ID_KEY
 import org.radarbase.connect.upload.converter.Converter.Companion.REVISION_KEY
-import org.radarbase.connect.upload.exception.BadGatewayException
+import org.radarbase.connect.upload.exception.ConflictException
+import org.radarbase.connect.upload.exception.StaleStateException
 import org.radarbase.connect.upload.util.VersionUtil
 import org.slf4j.LoggerFactory
 
@@ -63,28 +62,46 @@ class UploadSourceTask : SourceTask() {
     override fun poll(): List<SourceRecord> {
         logger.info("Poll with interval $pollInterval millseconds")
         while (true) {
-            val records = uploadClient.pollRecords(PollDTO(5, converters.map { it.sourceType })).records
-            logger.info("Received ${records.size} records")
-            for (record in records) {
-                val converter = converters.find { it.sourceType == record.sourceType }
-                try {
-                    if (converter == null) {
-                        uploadClient.updateStatus(record.id!!, record.metadata!!.copy(status = "FAILED", message = "Converter for Source type ${record.sourceType} not found."))
-                        continue
-                    } else {
-                        record.metadata = uploadClient.updateStatus(record.id!!, record.metadata!!.copy(status = "PROCESSING"))
-                        logger.debug("updated metadata ${record.metadata}")
+            var records: List<RecordDTO>? = null
+            try {
+                records = uploadClient.pollRecords(PollDTO(1, converters.map { it.sourceType })).records
+                logger.info("Received ${records.size} records")
+            } catch (exe: Exception) {
+                logger.info("Could not successfully poll records. Waiting for next polling...")
+            }
+            if(records != null) {
+                records@ for (record in records) {
+                    val converter = converters.find { it.sourceType == record.sourceType }
+                    try {
+                        if (converter == null) {
+                            uploadClient.updateStatus(record.id!!, record.metadata!!.copy(status = "FAILED", message = "Converter for Source type ${record.sourceType} not found."))
+                            logger.debug("Could not find converter $converter for record ${record.id}")
+                            continue
+                        } else {
+                            record.metadata = uploadClient.updateStatus(record.id!!, record.metadata!!.copy(status = "PROCESSING"))
+                            logger.debug("updated metadata ${record.metadata}")
+                        }
+                    } catch (exe: Exception) {
+                        when(exe) {
+                            is ConflictException -> {
+                                logger.warn("Conflicting request was made. Skipping this record")
+                                continue@records
+                            }
+                            is StaleStateException -> {
+                                logger.warn("Stale request state found. Skipping this record")
+                                continue@records
+                            }
+                            else -> throw exe
+                        }
                     }
-                } catch (exe: BadGatewayException) {
-                    logger.error("Could not update status for record ${record.id}", exe)
-                    continue
-                }
 
-                val result = converter.convert(record)
-                result.result?.takeIf(List<*>::isNotEmpty)?.let {
-                    return@poll it
+                    val result = converter.convert(record)
+                    result.result?.takeIf(List<*>::isNotEmpty)?.let {
+                        return@poll it
+                    }
                 }
             }
+
             Thread.sleep(pollInterval)
         }
     }

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/api/UploadBackendClient.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/api/UploadBackendClient.kt
@@ -7,7 +7,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import okhttp3.*
 import org.radarbase.connect.upload.exception.BadGatewayException
+import org.radarbase.connect.upload.exception.ConflictException
 import org.radarbase.connect.upload.exception.NotAuthorizedException
+import org.radarbase.connect.upload.exception.StaleStateException
 import org.slf4j.LoggerFactory
 import java.io.Closeable
 
@@ -94,6 +96,8 @@ class UploadBackendClient(
             when (response.code()) {
                 401 -> throw NotAuthorizedException("access token is not provided or is invalid : ${response.message()}")
                 403 -> throw NotAuthorizedException("access token is not authorized to perform this request")
+                400 -> throw StaleStateException("Could not perform request due stale state: ${response.message()}")
+                409 -> throw ConflictException("Conflicting request exception: ${response.message()}")
             }
             throw BadGatewayException("Failed to make request to ${request.url()}: Error code ${response.code()}:  ${response.body()?.string()}")
         }

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/api/UploadBackendClient.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/api/UploadBackendClient.kt
@@ -9,7 +9,6 @@ import okhttp3.*
 import org.radarbase.connect.upload.exception.BadGatewayException
 import org.radarbase.connect.upload.exception.ConflictException
 import org.radarbase.connect.upload.exception.NotAuthorizedException
-import org.radarbase.connect.upload.exception.StaleStateException
 import org.slf4j.LoggerFactory
 import java.io.Closeable
 
@@ -96,7 +95,6 @@ class UploadBackendClient(
             when (response.code()) {
                 401 -> throw NotAuthorizedException("access token is not provided or is invalid : ${response.message()}")
                 403 -> throw NotAuthorizedException("access token is not authorized to perform this request")
-                400 -> throw StaleStateException("Could not perform request due stale state: ${response.message()}")
                 409 -> throw ConflictException("Conflicting request exception: ${response.message()}")
             }
             throw BadGatewayException("Failed to make request to ${request.url()}: Error code ${response.code()}:  ${response.body()?.string()}")

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/exception/Exceptions.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/exception/Exceptions.kt
@@ -4,4 +4,8 @@ class NotAuthorizedException(message: String) : RuntimeException(message)
 
 class BadGatewayException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
+class StaleStateException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
+class ConflictException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
 class InvalidFormatException(message: String) : RuntimeException(message)

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/exception/Exceptions.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/exception/Exceptions.kt
@@ -4,8 +4,6 @@ class NotAuthorizedException(message: String) : RuntimeException(message)
 
 class BadGatewayException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
-class StaleStateException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
-
 class ConflictException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
 class InvalidFormatException(message: String) : RuntimeException(message)

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/exception/Exceptions.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/exception/Exceptions.kt
@@ -2,6 +2,6 @@ package org.radarbase.connect.upload.exception
 
 class NotAuthorizedException(message: String) : RuntimeException(message)
 
-class BadGatewayException(message: String) : RuntimeException(message)
+class BadGatewayException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
 class InvalidFormatException(message: String) : RuntimeException(message)

--- a/radar-upload-backend/src/main/java/org/radarbase/upload/doa/RecordRepositoryImpl.kt
+++ b/radar-upload-backend/src/main/java/org/radarbase/upload/doa/RecordRepositoryImpl.kt
@@ -14,7 +14,6 @@ import java.time.Instant
 import javax.persistence.EntityManager
 import javax.persistence.LockModeType
 import javax.persistence.PessimisticLockScope
-import javax.ws.rs.BadRequestException
 import javax.ws.rs.NotFoundException
 import javax.ws.rs.core.Context
 import kotlin.collections.HashSet
@@ -194,7 +193,7 @@ class RecordRepositoryImpl(@Context private var em: javax.inject.Provider<Entity
                 ?: throw NotFoundException("RecordMetadata with ID $id does not exist")
 
         if (existingMetadata.revision != metadata.revision)
-            throw BadRequestException("Requested meta data revision ${metadata.revision} " +
+            throw ConflictException("incompatible_revision", "Requested meta data revision ${metadata.revision} " +
                     "should match the latest existing revision ${existingMetadata.revision}")
 
         if (metadata.status == RecordStatus.PROCESSING.toString()

--- a/radar-upload-backend/src/main/java/org/radarbase/upload/exception/BadGatewayException.kt
+++ b/radar-upload-backend/src/main/java/org/radarbase/upload/exception/BadGatewayException.kt
@@ -1,6 +1,0 @@
-package org.radarbase.upload.exception
-
-import org.radarbase.appconfig.exception.HttpApplicationException
-import javax.ws.rs.core.Response.Status
-
-class BadGatewayException(message: String) : HttpApplicationException(Status.BAD_GATEWAY, "bad_gateway", message)

--- a/radar-upload-backend/src/main/java/org/radarbase/upload/exception/ConflictException.kt
+++ b/radar-upload-backend/src/main/java/org/radarbase/upload/exception/ConflictException.kt
@@ -1,8 +1,0 @@
-package org.radarbase.upload.exception
-
-import org.radarbase.appconfig.exception.HttpApplicationException
-import javax.ws.rs.ClientErrorException
-import javax.ws.rs.core.Response
-
-class ConflictException(code: String, messageText: String) :
-        HttpApplicationException(Response.Status.CONFLICT, code, messageText)

--- a/radar-upload-backend/src/main/java/org/radarbase/upload/exception/Exceptions.kt
+++ b/radar-upload-backend/src/main/java/org/radarbase/upload/exception/Exceptions.kt
@@ -1,0 +1,23 @@
+package org.radarbase.upload.exception
+
+import java.lang.RuntimeException
+import javax.ws.rs.core.Response.Status
+
+open class HttpApplicationException(val status: Int, val code: String, val detailedMessage: String?) : RuntimeException("[$status] $code: $detailedMessage") {
+    constructor(status: Status, code: String, detailedMessage: String?) : this(status.statusCode, code, detailedMessage)
+}
+
+class BadGatewayException(message: String) :
+        HttpApplicationException(Status.BAD_GATEWAY, "bad_gateway", message)
+
+class ConflictException(code: String, messageText: String) :
+        HttpApplicationException(Status.CONFLICT, code, messageText)
+
+class NotAuthorizedException(code: String, message: String)
+    : HttpApplicationException(Status.UNAUTHORIZED, code, message)
+
+class NotFoundException(code: String, message: String) :
+        HttpApplicationException(Status.NOT_FOUND, code, message)
+
+class InternalServerException(code: String, message: String) :
+        HttpApplicationException(Status.INTERNAL_SERVER_ERROR, code, message)

--- a/radar-upload-backend/src/main/java/org/radarbase/upload/exception/HttpApplicationException.kt
+++ b/radar-upload-backend/src/main/java/org/radarbase/upload/exception/HttpApplicationException.kt
@@ -1,8 +1,0 @@
-package org.radarbase.appconfig.exception
-
-import java.lang.RuntimeException
-import javax.ws.rs.core.Response
-
-open class HttpApplicationException(val status: Int, val code: String, val detailedMessage: String?) : RuntimeException("[$status] $code: $detailedMessage") {
-    constructor(status: Response.Status, code: String, detailedMessage: String?) : this(status.statusCode, code, detailedMessage)
-}

--- a/radar-upload-backend/src/main/java/org/radarbase/upload/exception/HttpApplicationExceptionMapper.kt
+++ b/radar-upload-backend/src/main/java/org/radarbase/upload/exception/HttpApplicationExceptionMapper.kt
@@ -1,4 +1,4 @@
-package org.radarbase.appconfig.exception
+package org.radarbase.upload.exception
 
 import com.fasterxml.jackson.core.util.BufferRecyclers
 import org.glassfish.jersey.message.internal.ReaderWriter

--- a/radar-upload-backend/src/main/java/org/radarbase/upload/exception/NotAuthorizedException.kt
+++ b/radar-upload-backend/src/main/java/org/radarbase/upload/exception/NotAuthorizedException.kt
@@ -1,8 +1,0 @@
-package org.radarbase.upload.exception
-
-import org.radarbase.appconfig.exception.HttpApplicationException
-import javax.ws.rs.core.Response
-
-class NotAuthorizedException(code: String, message: String)
-    : HttpApplicationException(Response.Status.UNAUTHORIZED, code, message)
-

--- a/radar-upload-backend/src/main/java/org/radarbase/upload/exception/NotFoundException.kt
+++ b/radar-upload-backend/src/main/java/org/radarbase/upload/exception/NotFoundException.kt
@@ -1,7 +1,0 @@
-package org.radarbase.upload.exception
-
-import org.radarbase.appconfig.exception.HttpApplicationException
-import javax.ws.rs.core.Response
-
-class NotFoundException(code: String, message: String) :
-        HttpApplicationException(Response.Status.NOT_FOUND, code, message)

--- a/radar-upload-backend/src/main/java/org/radarbase/upload/filter/AuthenticationFilter.kt
+++ b/radar-upload-backend/src/main/java/org/radarbase/upload/filter/AuthenticationFilter.kt
@@ -40,7 +40,7 @@ class AuthenticationFilter : ContainerRequestFilter {
         }
         logger.debug("Verified token : $radarToken for request ${requestContext.uriInfo.path}" )
         if (radarToken == null) {
-            logger.warn("[401] {}: Could not find a valid token in the header",
+            logger.debug("[401] {}: Could not find a valid token in the header",
                     requestContext.uriInfo.path)
             requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED)
                     .header("WWW-Authenticate", BEARER_REALM)

--- a/radar-upload-backend/src/main/java/org/radarbase/upload/inject/DoaEntityManagerFactory.kt
+++ b/radar-upload-backend/src/main/java/org/radarbase/upload/inject/DoaEntityManagerFactory.kt
@@ -40,8 +40,10 @@ fun <T> EntityManager.transact(transaction: EntityManager.() -> T): T {
         try {
             getTransaction().commit()
         } catch (exe: Exception) {
-            logger.warn("Rolling back operation: {}", exe.toString())
-            getTransaction().rollback()
+            logger.error("Rolling back operation: {}", exe)
+            if(getTransaction() != null && getTransaction().isActive) {
+                getTransaction().rollback()
+            }
         }
     }
 }

--- a/radar-upload-backend/src/main/java/org/radarbase/upload/inject/DoaEntityManagerFactory.kt
+++ b/radar-upload-backend/src/main/java/org/radarbase/upload/inject/DoaEntityManagerFactory.kt
@@ -1,17 +1,10 @@
 package org.radarbase.upload.inject
 
-import liquibase.Liquibase
-import liquibase.database.DatabaseFactory
-import liquibase.database.jvm.JdbcConnection
-import liquibase.exception.LiquibaseException
-import liquibase.resource.ClassLoaderResourceAccessor
 import org.glassfish.jersey.internal.inject.DisposableSupplier
 import org.hibernate.Session
-import org.hibernate.internal.SessionImpl
 import org.radarbase.upload.logger
 import org.slf4j.LoggerFactory
 import java.lang.Exception
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.ws.rs.core.Context


### PR DESCRIPTION
- Using explicit locking to prevent concurrent writing. This finally prevents multiple tasks processing the same record. 
- Adds specific exceptions to handle 