### PR TITLE
Release 0.5.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 subprojects {
     group = "org.radarbase"
-    version = "0.5.1"
+    version = "0.5.2-SNAPSHOT"
 }
 
 tasks.wrapper {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 subprojects {
     group = "org.radarbase"
-    version = "0.5.2-SNAPSHOT"
+    version = "0.5.2"
 
     project.extra.apply {
         set("kafkaVersion", "2.5.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,31 @@ plugins {
 subprojects {
     group = "org.radarbase"
     version = "0.5.2-SNAPSHOT"
+
+    project.extra.apply {
+        set("kafkaVersion", "2.5.0")
+        set("okhttpVersion", "4.8.0")
+        set("jacksonVersion", "2.11.1")
+        set("jacksonDataVersion", "2.11.1")
+        set("openCsvVersion", "5.2")
+        set("confluentVersion", "5.5.1")
+        set("radarSchemaVersion", "0.5.11.1")
+        set("slf4jVersion", "1.7.30")
+        set("minioVersion", "7.1.0")
+
+        set("radarJerseyVersion", "0.2.3")
+        set("radarCommonsVersion", "0.13.0")
+        set("logbackVersion", "1.2.3")
+        set("grizzlyVersion", "2.4.4")
+        set("jerseyVersion", "2.31")
+        set("hibernateVersion", "5.4.19.Final")
+        set("postgresqlVersion", "42.2.14")
+        set("h2Version", "1.4.200")
+        set("liquibaseVersion", "3.10.2")
+
+        set("junitVersion", "5.6.2")
+        set("mockitoKotlinVersion", "2.2.0")
+    }
 }
 
 tasks.wrapper {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,7 +182,7 @@ services:
     build:
       context: .
       dockerfile: kafka-connect-upload-source/Dockerfile
-    image: radarbase/radar-connect-upload-source:0.4.1
+    image: radarbase/radar-connect-upload-source:0.5.1
     restart: on-failure
     volumes:
       - ./etc/source-upload.properties:/etc/kafka-connect/source-upload.properties
@@ -221,7 +221,7 @@ services:
     build:
       context: .
       dockerfile: radar-upload-backend/Dockerfile
-    image: radarbase/radar-upload-connect-backend:0.4.1
+    image: radarbase/radar-upload-connect-backend:0.5.1
     ports:
       - "8085:8085"
     depends_on:
@@ -238,7 +238,7 @@ services:
     build:
       context: radar-upload-frontend
       dockerfile: Dockerfile
-    image: radarbase/radar-upload-connect-frontend:0.4.1
+    image: radarbase/radar-upload-connect-frontend:0.5.1
     depends_on:
       - radar-upload-backend
       - managementportal-app

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -6,13 +6,6 @@ plugins {
     kotlin("jvm")
 }
 
-project.extra.apply {
-    set("okhttpVersion", "4.8.0")
-    set("kafkaVersion", "2.5.0")
-    set("jacksonVersion", "2.11.1")
-    set("jacksonDataVersion", "2.11.1")
-}
-
 repositories {
     jcenter()
     mavenLocal()
@@ -44,10 +37,10 @@ dependencies {
 
     testImplementation(project(":radar-upload-backend"))
     testImplementation(project(":kafka-connect-upload-source"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:${project.extra["junitVersion"]}")
     testImplementation("org.hamcrest:hamcrest-all:1.3")
     testImplementation("org.apache.kafka:connect-api:${project.extra["kafkaVersion"]}")
-    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
+    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:${project.extra["mockitoKotlinVersion"]}")
 }
 
 tasks.withType<KotlinCompile> {

--- a/kafka-connect-upload-source/Dockerfile
+++ b/kafka-connect-upload-source/Dockerfile
@@ -8,7 +8,7 @@ COPY kafka-connect-upload-source/build.gradle.kts  /code/kafka-connect-upload-so
 
 RUN gradle :kafka-connect-upload-source:downloadDependencies kafka-connect-upload-source:copyDependencies
 
-COPY ./kafka-connect-upload-source/src/ /code/kafka-connect-upload-source/src
+COPY ./kafka-connect-upload-source/src/main/java /code/kafka-connect-upload-source/src/main/java
 
 RUN gradle jar
 

--- a/kafka-connect-upload-source/build.gradle.kts
+++ b/kafka-connect-upload-source/build.gradle.kts
@@ -6,18 +6,6 @@ plugins {
     kotlin("jvm")
 }
 
-project.extra.apply {
-    set("kafkaVersion", "2.5.0")
-    set("okhttpVersion", "4.8.0")
-    set("jacksonVersion", "2.11.1")
-    set("jacksonDataVersion", "2.11.1")
-    set("openCsvVersion", "5.2")
-    set("confluentVersion", "5.5.1")
-    set("radarSchemaVersion", "0.5.11.1")
-    set("slf4jVersion", "1.7.30")
-    set("minioVersion", "7.1.0")
-}
-
 repositories {
     jcenter()
     maven(url = "https://packages.confluent.io/maven/")

--- a/kafka-connect-upload-source/src/main/docker/launch
+++ b/kafka-connect-upload-source/src/main/docker/launch
@@ -49,4 +49,4 @@ echo "===> Launching ${COMPONENT} ..."
 export CLASSPATH="/etc/${COMPONENT}/kafka-connect-upload-source/*"
 
 # execute connector in standalone mode
-exec connect-standalone /etc/"${COMPONENT}"/"${COMPONENT}".properties $(find /etc/"${COMPONENT}"/ -type f -name "${CONNECTOR_PROPERTY_FILE_PREFIX}*.properties")
+exec connect-standalone /etc/"${COMPONENT}"/"${COMPONENT}".properties "/etc/${COMPONENT}"/"${CONNECTOR_PROPERTY_FILE_PREFIX}".properties

--- a/radar-upload-backend/build.gradle.kts
+++ b/radar-upload-backend/build.gradle.kts
@@ -13,21 +13,6 @@ application {
     mainClassName = "org.radarbase.upload.MainKt"
 }
 
-project.extra.apply {
-    set("okhttpVersion", "4.8.0")
-    set("radarJerseyVersion", "0.2.3")
-    set("radarCommonsVersion", "0.13.0")
-    set("jacksonVersion", "2.11.1")
-    set("slf4jVersion", "1.7.30")
-    set("logbackVersion", "1.2.3")
-    set("grizzlyVersion", "2.4.4")
-    set("jerseyVersion", "2.31")
-    set("hibernateVersion", "5.4.19.Final")
-    set("postgresqlVersion", "42.2.14")
-    set("h2Version", "1.4.200")
-    set("liquibaseVersion", "3.10.2")
-}
-
 repositories {
     jcenter()
     maven(url = "https://dl.bintray.com/radar-base/org.radarbase")

--- a/radar-upload-frontend/package.json
+++ b/radar-upload-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-upload-frontend",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
Changes since version 0.5.1:
- Fix connector docker initialization
- Moved dependency versions to a single place

Note: the environment variable `CONNECTOR_PROPERTY_FILE_PREFIX` must now include subdirectories if any. It is used in the following path: `/etc/kafka-connect/${CONNECTOR_PROPERTY_FILE_PREFIX}.properties`, e.g.
for `/etc/kafka-connect/source-upload/source-upload.properties`, `CONNECTOR_PROPERTY_FILE_PREFIX=source-upload/source-upload`.