### PR TITLE
Polling fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,8 @@
+plugins {
+    kotlin("jvm") apply false
+}
+
+
 subprojects {
     group = "org.radarbase"
     version = "0.5.4-SNAPSHOT"

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -44,7 +44,11 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions {
+        jvmTarget = "11"
+        apiVersion = "1.4"
+        languageVersion = "1.4"
+    }
 }
 
 task<Test>("integrationTest") {

--- a/integration-test/src/integrationTest/java/org/radarbase/connect/upload/UploadSourceTaskTest.kt
+++ b/integration-test/src/integrationTest/java/org/radarbase/connect/upload/UploadSourceTaskTest.kt
@@ -98,6 +98,7 @@ class UploadSourceTaskTest {
 
         val sourceRecords = sourceTask.poll()
         assertNotNull(sourceRecords)
+        sourceRecords ?: return
 
         val metadata = retrieveRecordMetadata(accessToken, createdRecord.id!!)
         assertNotNull(metadata)
@@ -120,8 +121,7 @@ class UploadSourceTaskTest {
         assertNotNull(createdRecord.id)
 
         val sourceRecords = sourceTask.poll()
-        assertNotNull(sourceRecords)
-        assertTrue(sourceRecords.isEmpty())
+        assertNull(sourceRecords)
 
         val metadata = retrieveRecordMetadata(accessToken, createdRecord.id!!)
         assertNotNull(metadata)
@@ -137,8 +137,7 @@ class UploadSourceTaskTest {
         assertNotNull(createdRecord.id)
 
         val sourceRecords = sourceTask.poll()
-        assertNotNull(sourceRecords)
-        assertTrue(sourceRecords.isEmpty())
+        assertNull(sourceRecords)
 
         val metadata = retrieveRecordMetadata(accessToken, createdRecord.id!!)
         assertNotNull(metadata)

--- a/integration-test/src/integrationTest/java/org/radarbase/connect/upload/io/S3FileUploaderTest.kt
+++ b/integration-test/src/integrationTest/java/org/radarbase/connect/upload/io/S3FileUploaderTest.kt
@@ -99,7 +99,6 @@ class S3FileUploaderTest {
 
         s3Client.listObjects(ROOT).forEach {
             assertTrue(OBJECT_NAME_REGEX.matchEntire(it.get().objectName()) != null, "URL ${it.get().objectName()} does not match regex $OBJECT_NAME_REGEX")
-
         }
     }
 

--- a/kafka-connect-upload-source/build.gradle.kts
+++ b/kafka-connect-upload-source/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     // Included in connector runtime
     compileOnly("org.apache.kafka:connect-api:${project.extra["kafkaVersion"]}")
     implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("reflect"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.4.2")
     testImplementation("org.hamcrest:hamcrest-all:1.3")
@@ -52,7 +53,11 @@ dependencies {
 
 // config JVM target to 1.8 for kotlin compilation tasks
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions {
+        jvmTarget = "1.8"
+        apiVersion = "1.4"
+        languageVersion = "1.4"
+    }
 }
 
 task<Test>("integrationTest") {

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/UploadSourceTask.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/UploadSourceTask.kt
@@ -85,7 +85,7 @@ class UploadSourceTask : SourceTask() {
 
     override fun version(): String = VersionUtil.getVersion()
 
-    override fun poll(): List<SourceRecord> {
+    override fun poll(): List<SourceRecord>? {
         val timeout = nextPoll.untilNow().toMillis()
         if (timeout > 0) {
             logger.info("Waiting {} milliseconds for next polling time", timeout)
@@ -95,17 +95,19 @@ class UploadSourceTask : SourceTask() {
         logger.info("Polling new records...")
         val records: List<RecordDTO> = try {
             uploadClient.pollRecords(PollDTO(1, converters.keys)).records
-        } catch (exe: Exception) {
-            logger.info("Could not successfully poll records. Waiting for next polling...")
+        } catch (exe: Throwable) {
+            logger.error("Could not successfully poll records. Waiting for next polling...")
             nextPoll = failedPollInterval.fromNow()
-            return emptyList()
+            return null
         }
 
         nextPoll = pollInterval.fromNow()
 
         logger.info("Received ${records.size} records at $nextPoll")
 
-        return records.flatMap { record -> processRecord(record) ?: emptyList() }
+        return records
+                .flatMap { record -> processRecord(record) ?: emptyList() }
+                .takeIf { it.isNotEmpty() }
     }
 
     private fun processRecord(record: RecordDTO): List<SourceRecord>? {
@@ -117,12 +119,17 @@ class UploadSourceTask : SourceTask() {
 
             converter.convert(record)
         } catch (exe: ConversionFailedException) {
-            logger.error("Could not convert record ${record.id}", exe)
+            logger.error("Could not convert record {}", record.id, exe)
             updateRecordFailure(record, exe)
             null
         } catch (exe: ConversionTemporarilyFailedException) {
-            logger.error("Could not convert record ${record.id} due to temporary failure", exe)
+            logger.error("Could not convert record {} due to temporary failure", record.id, exe)
             updateRecordTemporaryFailure(record, exe)
+            null
+        } catch (exe: Throwable) {
+            logger.error("Could not convert record {} due to application failure", record.id, exe)
+            updateRecordTemporaryFailure(record,
+                    ConversionTemporarilyFailedException("Could not convert record ${record.id} due to application failure", exe))
             null
         }
     }
@@ -145,17 +152,18 @@ class UploadSourceTask : SourceTask() {
     }
 
     private fun updateRecordFailure(record: RecordDTO, exe: Exception, reason: String = "Could not convert this record. Please refer to the conversion logs for more details") {
-        val recordLogger = logRepository.createLogger(logger, record.id!!)
+        val recordId = record.id ?: return
+        val recordLogger = logRepository.createLogger(logger, recordId)
         recordLogger.error(reason, exe)
-        val metadata = uploadClient.retrieveRecordMetadata(record.id!!)
-        val updatedMetadata = uploadClient.updateStatus(record.id!!, metadata.copy(
+        val metadata = uploadClient.retrieveRecordMetadata(recordId)
+        val updatedMetadata = uploadClient.updateStatus(recordId, metadata.copy(
                 status = "FAILED",
                 message = reason
         ))
 
         if (updatedMetadata.status == "FAILED") {
             logger.info("Uploading logs to backend")
-            uploadLogs(record.id!!)
+            uploadLogs(recordId)
         }
     }
 

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/UploadSourceTask.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/UploadSourceTask.kt
@@ -194,7 +194,9 @@ class UploadSourceTask : SourceTask() {
 
         if (endOfRecord) {
             logger.info("Committing last record of Record $recordId, with Revision $revision")
-            val updatedMetadata = uploadClient.updateStatus(recordId.toLong(), RecordMetadataDTO(revision = revision.toInt(), status = "SUCCEEDED", message = "Record has been processed successfully"))
+            val updatedMetadata = uploadClient.updateStatus(
+                    recordId.toLong(),
+                    RecordMetadataDTO(revision = revision.toInt(), status = "SUCCEEDED", message = "Record has been processed successfully"))
 
             if (updatedMetadata.status == "SUCCEEDED") {
                 logger.info("Uploading logs to backend")

--- a/radar-upload-backend/build.gradle.kts
+++ b/radar-upload-backend/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
 
 dependencies {
     api(kotlin("stdlib-jdk8"))
+    implementation(kotlin("reflect"))
 
     implementation("org.radarbase:radar-jersey:${project.extra["radarJerseyVersion"]}")
 
@@ -50,7 +51,11 @@ dependencies {
 
 // config JVM target to 1.8 for kotlin compilation tasks
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions {
+        jvmTarget = "11"
+        apiVersion = "1.4"
+        languageVersion = "1.4"
+    }
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
Attempted fix for when the connector stops polling. Expected problem: a throwable (OutOfMemoryException) or an exception not handled during conversion.

Also: return null instead of an empty list if no records are found or converted.