### PR TITLE
Ensure that initial file changelog file still works

### DIFF
--- a/radar-upload-backend/src/main/resources/db/changelog/changes/00000000000000_initial_schema.xml
+++ b/radar-upload-backend/src/main/resources/db/changelog/changes/00000000000000_initial_schema.xml
@@ -22,7 +22,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd"
+        logicalFilePath="dbChangelog.xml">
     <property name="autoIncrement" value="true" dbms="mysql,h2,postgresql,oracle,mssql"/>
 
     <changeSet id="0" author="joris" dbms="h2,postgresql">

--- a/radar-upload-backend/src/main/resources/db/changelog/changes/00000000000000_initial_schema.xml
+++ b/radar-upload-backend/src/main/resources/db/changelog/changes/00000000000000_initial_schema.xml
@@ -22,15 +22,45 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd"
-        logicalFilePath="dbChangelog.xml">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd">
     <property name="autoIncrement" value="true" dbms="mysql,h2,postgresql,oracle,mssql"/>
 
     <changeSet id="0" author="joris" dbms="h2,postgresql">
+        <preConditions onFail="MARK_RAN">
+            <sequenceExists sequenceName="hibernate_sequence"/>
+        </preConditions>
         <createSequence sequenceName="hibernate_sequence" startValue="1" incrementBy="1"/>
     </changeSet>
 
     <changeSet id="1" author="joris">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <not>
+                    <tableExists tableName="record"/>
+                </not>
+                <not>
+                    <tableExists tableName="record_metadata"/>
+                </not>
+                <not>
+                    <tableExists tableName="record_logs"/>
+                </not>
+                <not>
+                    <tableExists tableName="record_content"/>
+                </not>
+                <not>
+                    <tableExists tableName="source_type"/>
+                </not>
+                <not>
+                    <tableExists tableName="source_type_topics"/>
+                </not>
+                <not>
+                    <tableExists tableName="source_type_content_types"/>
+                </not>
+                <not>
+                    <tableExists tableName="source_type_configuration"/>
+                </not>
+            </and>
+        </preConditions>
         <comment>Create Record table</comment>
         <createTable tableName="record">
             <column name="id" type="bigint" autoIncrement="${autoIncrement}">

--- a/radar-upload-backend/src/main/resources/db/changelog/changes/00000000000000_initial_schema.xml
+++ b/radar-upload-backend/src/main/resources/db/changelog/changes/00000000000000_initial_schema.xml
@@ -27,7 +27,9 @@
 
     <changeSet id="0" author="joris" dbms="h2,postgresql">
         <preConditions onFail="MARK_RAN">
-            <sequenceExists sequenceName="hibernate_sequence"/>
+            <not>
+                <sequenceExists sequenceName="hibernate_sequence"/>
+            </not>
         </preConditions>
         <createSequence sequenceName="hibernate_sequence" startValue="1" incrementBy="1"/>
     </changeSet>


### PR DESCRIPTION
This checks whether the tables have already been created. If so, the old ID may have been used, so skip the transition.