### PR TITLE
Assert that csv processors with matching suffix are used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ services:
   - docker
 
 env:
-  - DOCKER_COMPOSE_FILE=integration-test/docker-compose.yml
+  global:
+    - DOCKER_COMPOSE_FILE=integration-test/docker-compose.yml
 
 cache:
   directories:
@@ -21,6 +22,7 @@ cache:
     - $HOME/build/RADAR-base/radar-upload-source-connector/radar-upload-frontend/node_modules/
 
 before_install:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker-compose --version
   - nvm install
 

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/CsvLineProcessorFactory.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/CsvLineProcessorFactory.kt
@@ -29,8 +29,10 @@ interface CsvLineProcessorFactory {
      */
     val optional: Boolean
 
-    /** Whether this factory should also match the header before selection. */
-    val conditionalMatchOnHeader: Boolean
+    /**
+     * Whether this factory must match the header of a CSV file if the file name matched.
+     */
+    val headerMustMatch: Boolean
 
     /** Upper case header list. */
     val header: List<String>

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/CsvLineProcessorFactory.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/CsvLineProcessorFactory.kt
@@ -29,6 +29,9 @@ interface CsvLineProcessorFactory {
      */
     val optional: Boolean
 
+    /** Whether this factory should also match the header before selection. */
+    val conditionalMatchOnHeader: Boolean
+
     /** Upper case header list. */
     val header: List<String>
 

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/CsvProcessor.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/CsvProcessor.kt
@@ -58,14 +58,14 @@ open class CsvProcessor(
                     .filter {
                         when {
                             it.matches(header) -> true
-                            it.conditionalMatchOnHeader -> false
-                            else -> throw InvalidFormatException(
+                            it.headerMustMatch -> throw InvalidFormatException(
                                 """
                                     CSV header of file ${contents.fileName} in record ${record.id} did not match processor ${it.javaClass}
                                         Found:    $header
                                         Expected: ${it.header}
                                 """.trimIndent()
                             )
+                            else -> false
                         }
                     }
                     .map { it.createLineProcessor(record, logRepository) }

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/CsvProcessor.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/CsvProcessor.kt
@@ -3,7 +3,6 @@ package org.radarbase.connect.upload.converter
 import com.opencsv.CSVParserBuilder
 import com.opencsv.CSVReader
 import com.opencsv.CSVReaderBuilder
-import org.apache.commons.beanutils.ConversionException
 import org.radarbase.connect.upload.api.ContentsDTO
 import org.radarbase.connect.upload.api.RecordDTO
 import org.radarbase.connect.upload.exception.InvalidFormatException
@@ -60,9 +59,9 @@ open class CsvProcessor(
                         when {
                             it.matches(header) -> true
                             it.conditionalMatchOnHeader -> false
-                            else -> throw ConversionException(
+                            else -> throw InvalidFormatException(
                                 """
-                                    Header of record ${record.id} did not match processor ${it.javaClass}
+                                    CSV header of file ${contents.fileName} in record ${record.id} did not match processor ${it.javaClass}
                                         Found:    $header
                                         Expected: ${it.header}
                                 """.trimIndent()
@@ -71,7 +70,7 @@ open class CsvProcessor(
                     }
                     .map { it.createLineProcessor(record, logRepository) }
                     .takeIf { it.isNotEmpty() }
-                    ?: throw InvalidFormatException("In record ${record.id}, cannot find CSV processor that matches header $header")
+                    ?: throw InvalidFormatException("For file ${contents.fileName} in record ${record.id}, cannot find CSV processor that matches header $header")
 
             generateSequence { reader.readNext() }
                     .map { line ->

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/RecordConverter.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/RecordConverter.kt
@@ -95,8 +95,10 @@ class RecordConverter(
 
         try {
             return processorFactories
-                    .flatMap { it.createProcessor(record)
-                            .processData(contents, inputStream, System.currentTimeMillis() / 1000.0) }
+                    .flatMap {
+                        it.createProcessor(record)
+                            .processData(contents, inputStream, System.currentTimeMillis() / 1000.0)
+                    }
                     .also { it.lastOrNull()?.endOfFileOffSet = true }
         } catch (exe: Exception) {
             recordLogger.error("Could not convert record ${record.id}", exe)

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/StatelessCsvLineProcessor.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/StatelessCsvLineProcessor.kt
@@ -30,6 +30,10 @@ abstract class StatelessCsvLineProcessor: CsvLineProcessorFactory {
 
     open val fileNameSuffix: String = ".csv"
 
+    /** Whether this factory should also match the header before selection. */
+    override val conditionalMatchOnHeader: Boolean
+        get() = fileNameSuffixes == listOf(".csv")
+
     override val optional: Boolean = false
 
     open val timeFieldParser: TimeFieldParser = TimeFieldParser.EpochMillisParser()

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/StatelessCsvLineProcessor.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/StatelessCsvLineProcessor.kt
@@ -30,9 +30,8 @@ abstract class StatelessCsvLineProcessor: CsvLineProcessorFactory {
 
     open val fileNameSuffix: String = ".csv"
 
-    /** Whether this factory should also match the header before selection. */
-    override val conditionalMatchOnHeader: Boolean
-        get() = fileNameSuffixes == listOf(".csv")
+    override val headerMustMatch: Boolean
+        get() = fileNameSuffixes != listOf(".csv")
 
     override val optional: Boolean = false
 


### PR DESCRIPTION
Adds a variable for when a file should only be processed conditional on its header. If false, a header mismatch will throw a ConversionException.