### PR TITLE
Add allowUnmappedFiles property to ZipFileProcessorFactory

### DIFF
--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/ZipFileProcessorFactory.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/ZipFileProcessorFactory.kt
@@ -74,20 +74,20 @@ open class ZipFileProcessorFactory(
                         .forEach { zipEntry ->
                             try {
                                 delegatingProcessor.processData(
-                                        context = context.copy(
-                                                contents = ContentsDTO(
-                                                        fileName = zipEntry.name.trim(),
-                                                        size = zipEntry.size
-                                                ),
+                                    context = context.copy(
+                                        contents = ContentsDTO(
+                                            fileName = zipEntry.name.trim(),
+                                            size = zipEntry.size
                                         ),
-                                        inputStream = object : FilterInputStream(zipInputStream) {
-                                            @Throws(IOException::class)
-                                            override fun close() {
-                                                context.logger.debug("Closing entry ${context.fileName}")
-                                                zipInputStream.closeEntry()
-                                            }
-                                        },
-                                        produce,
+                                    ),
+                                    inputStream = object : FilterInputStream(zipInputStream) {
+                                        @Throws(IOException::class)
+                                        override fun close() {
+                                            context.logger.debug("Closing entry ${context.fileName}")
+                                            zipInputStream.closeEntry()
+                                        }
+                                    },
+                                    produce,
                                 )
                             }
                             catch (exception: DataProcessorNotFoundException) {

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/ZipFileProcessorFactory.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/ZipFileProcessorFactory.kt
@@ -91,8 +91,8 @@ open class ZipFileProcessorFactory(
                                 )
                             }
                             catch (exception: DataProcessorNotFoundException) {
-                              if (!allowUnmappedFiles) throw exception
-                              context.logger.info("Skipping unmapped file ${zipEntry.name}..")
+                                if (!allowUnmappedFiles) throw exception
+                                context.logger.info("Skipping unmapped file ${zipEntry.name}..")
                             }
                         }
                 }

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/altoida/AltoidaConverterFactory.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/altoida/AltoidaConverterFactory.kt
@@ -21,7 +21,10 @@ package org.radarbase.connect.upload.converter.altoida
 
 import org.radarbase.connect.upload.api.SourceTypeDTO
 import org.radarbase.connect.upload.converter.*
-import org.radarbase.connect.upload.converter.altoida.summary.*
+import org.radarbase.connect.upload.converter.altoida.summary.AltoidaDomainResultProcessor
+import org.radarbase.connect.upload.converter.altoida.summary.AltoidaSummaryCsvPreProcessorFactory
+import org.radarbase.connect.upload.converter.altoida.summary.AltoidaSummaryProcessor
+import org.radarbase.connect.upload.converter.altoida.summary.AltoidaTestMetricsProcessor
 
 class AltoidaConverterFactory : ConverterFactory {
     override val sourceType: String = "altoida"
@@ -31,41 +34,42 @@ class AltoidaConverterFactory : ConverterFactory {
             connectorConfig: SourceTypeDTO,
             logRepository: LogRepository
     ): List<FileProcessorFactory> = listOf(
-        // Preprocess malformed export.csv
-        AltoidaSummaryCsvPreProcessorFactory(),
-        // Process export.csv
-        CsvFileProcessorFactory(
-            csvProcessorFactories = listOf(
-                AltoidaSummaryProcessor(),
-                AltoidaDomainResultProcessor(),
-                AltoidaTestMetricsProcessor(AltoidaTestMetricsProcessor.AltoidaTestCategory.BIT, "connect_upload_altoida_bit_metrics"),
-                AltoidaTestMetricsProcessor(AltoidaTestMetricsProcessor.AltoidaTestCategory.DOT, "connect_upload_altoida_dot_metrics"),
+            // Preprocess malformed export.csv
+            AltoidaSummaryCsvPreProcessorFactory(),
+            // Process export.csv
+            CsvFileProcessorFactory(
+                    csvProcessorFactories = listOf(
+                            AltoidaSummaryProcessor(),
+                            AltoidaDomainResultProcessor(),
+                            AltoidaTestMetricsProcessor(AltoidaTestMetricsProcessor.AltoidaTestCategory.BIT, "connect_upload_altoida_bit_metrics"),
+                            AltoidaTestMetricsProcessor(AltoidaTestMetricsProcessor.AltoidaTestCategory.DOT, "connect_upload_altoida_dot_metrics"),
+                    ),
             ),
-        ),
-        // Process zip file with detailed CSV contents
-        ZipFileProcessorFactory(
-            sourceType,
-            zipEntryProcessors = listOf(
-                CsvFileProcessorFactory(
-                    csvProcessorFactories =  listOf(
-                        AltoidaAccelerationCsvProcessor(),
-                        AltoidaActionCsvProcessor(),
-                        AltoidaAttitudeCsvProcessor(),
-                        AltoidaBlinkCsvProcessor(),
-                        AltoidaDiagnosticsCsvProcessor(),
-                        AltoidaEyeTrackingCsvProcessor(),
-                        AltoidaGravityCsvProcessor(),
-                        AltoidaMagneticFieldCsvProcessor(),
-                        AltoidaObjectCsvProcessor(),
-                        AltoidaPathCsvProcessor(),
-                        AltoidaRotationCsvProcessor(),
-                        AltoidaTapScreenCsvProcessor(),
-                        AltoidaTouchScreenCsvProcessor(),
-                    )
-                ),
-                AltoidaMetadataFileProcessor(),
-            )
-        ),
+            // Process zip file with detailed CSV contents
+            ZipFileProcessorFactory(
+                    sourceType,
+                    zipEntryProcessors = listOf(
+                            CsvFileProcessorFactory(
+                                    csvProcessorFactories = listOf(
+                                            AltoidaAccelerationCsvProcessor(),
+                                            AltoidaActionCsvProcessor(),
+                                            AltoidaAttitudeCsvProcessor(),
+                                            AltoidaBlinkCsvProcessor(),
+                                            AltoidaDiagnosticsCsvProcessor(),
+                                            AltoidaEyeTrackingCsvProcessor(),
+                                            AltoidaGravityCsvProcessor(),
+                                            AltoidaMagneticFieldCsvProcessor(),
+                                            AltoidaObjectCsvProcessor(),
+                                            AltoidaPathCsvProcessor(),
+                                            AltoidaRotationCsvProcessor(),
+                                            AltoidaTapScreenCsvProcessor(),
+                                            AltoidaTouchScreenCsvProcessor(),
+                                    )
+                            ),
+                            AltoidaMetadataFileProcessor(),
+                    ),
+                    allowUnmappedFiles = true
+            ),
     )
 }
 

--- a/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/altoida/AltoidaConverterFactory.kt
+++ b/kafka-connect-upload-source/src/main/java/org/radarbase/connect/upload/converter/altoida/AltoidaConverterFactory.kt
@@ -21,10 +21,7 @@ package org.radarbase.connect.upload.converter.altoida
 
 import org.radarbase.connect.upload.api.SourceTypeDTO
 import org.radarbase.connect.upload.converter.*
-import org.radarbase.connect.upload.converter.altoida.summary.AltoidaDomainResultProcessor
-import org.radarbase.connect.upload.converter.altoida.summary.AltoidaSummaryCsvPreProcessorFactory
-import org.radarbase.connect.upload.converter.altoida.summary.AltoidaSummaryProcessor
-import org.radarbase.connect.upload.converter.altoida.summary.AltoidaTestMetricsProcessor
+import org.radarbase.connect.upload.converter.altoida.summary.*
 
 class AltoidaConverterFactory : ConverterFactory {
     override val sourceType: String = "altoida"
@@ -34,42 +31,42 @@ class AltoidaConverterFactory : ConverterFactory {
             connectorConfig: SourceTypeDTO,
             logRepository: LogRepository
     ): List<FileProcessorFactory> = listOf(
-            // Preprocess malformed export.csv
-            AltoidaSummaryCsvPreProcessorFactory(),
-            // Process export.csv
-            CsvFileProcessorFactory(
+        // Preprocess malformed export.csv
+        AltoidaSummaryCsvPreProcessorFactory(),
+        // Process export.csv
+        CsvFileProcessorFactory(
+            csvProcessorFactories = listOf(
+                AltoidaSummaryProcessor(),
+                AltoidaDomainResultProcessor(),
+                AltoidaTestMetricsProcessor(AltoidaTestMetricsProcessor.AltoidaTestCategory.BIT, "connect_upload_altoida_bit_metrics"),
+                AltoidaTestMetricsProcessor(AltoidaTestMetricsProcessor.AltoidaTestCategory.DOT, "connect_upload_altoida_dot_metrics"),
+            ),
+        ),
+        // Process zip file with detailed CSV contents
+        ZipFileProcessorFactory(
+            sourceType,
+            zipEntryProcessors = listOf(
+                CsvFileProcessorFactory(
                     csvProcessorFactories = listOf(
-                            AltoidaSummaryProcessor(),
-                            AltoidaDomainResultProcessor(),
-                            AltoidaTestMetricsProcessor(AltoidaTestMetricsProcessor.AltoidaTestCategory.BIT, "connect_upload_altoida_bit_metrics"),
-                            AltoidaTestMetricsProcessor(AltoidaTestMetricsProcessor.AltoidaTestCategory.DOT, "connect_upload_altoida_dot_metrics"),
-                    ),
+                        AltoidaAccelerationCsvProcessor(),
+                        AltoidaActionCsvProcessor(),
+                        AltoidaAttitudeCsvProcessor(),
+                        AltoidaBlinkCsvProcessor(),
+                        AltoidaDiagnosticsCsvProcessor(),
+                        AltoidaEyeTrackingCsvProcessor(),
+                        AltoidaGravityCsvProcessor(),
+                        AltoidaMagneticFieldCsvProcessor(),
+                        AltoidaObjectCsvProcessor(),
+                        AltoidaPathCsvProcessor(),
+                        AltoidaRotationCsvProcessor(),
+                        AltoidaTapScreenCsvProcessor(),
+                        AltoidaTouchScreenCsvProcessor(),
+                    )
+                ),
+                AltoidaMetadataFileProcessor(),
             ),
-            // Process zip file with detailed CSV contents
-            ZipFileProcessorFactory(
-                    sourceType,
-                    zipEntryProcessors = listOf(
-                            CsvFileProcessorFactory(
-                                    csvProcessorFactories = listOf(
-                                            AltoidaAccelerationCsvProcessor(),
-                                            AltoidaActionCsvProcessor(),
-                                            AltoidaAttitudeCsvProcessor(),
-                                            AltoidaBlinkCsvProcessor(),
-                                            AltoidaDiagnosticsCsvProcessor(),
-                                            AltoidaEyeTrackingCsvProcessor(),
-                                            AltoidaGravityCsvProcessor(),
-                                            AltoidaMagneticFieldCsvProcessor(),
-                                            AltoidaObjectCsvProcessor(),
-                                            AltoidaPathCsvProcessor(),
-                                            AltoidaRotationCsvProcessor(),
-                                            AltoidaTapScreenCsvProcessor(),
-                                            AltoidaTouchScreenCsvProcessor(),
-                                    )
-                            ),
-                            AltoidaMetadataFileProcessor(),
-                    ),
-                    allowUnmappedFiles = true
-            ),
+            allowUnmappedFiles = true,
+        ),
     )
 }
 


### PR DESCRIPTION
- Add `allowUnmappedFiles` property to ZipFileProcessorFactory to allow skipping of files when processor is not found
- Set `allowUnmappedFiles` to true for Altoida zip files
- Reformat code