### PR TITLE
Refactor Kafka wait for KRaft compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
     group = "org.radarbase"
-    version = "0.5.15"
+    version = "0.6.1"
 }
 
 

--- a/kafka-connect-upload-source/Dockerfile
+++ b/kafka-connect-upload-source/Dockerfile
@@ -21,7 +21,7 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.authors="@pvannierop"
 LABEL description="Kafka Data Upload Source connector"
 
-ENV CONNECT_PLUGIN_PATH /usr/share/java/kafka-connect/plugins
+ENV CONNECT_PLUGIN_PATH=/usr/share/java/kafka-connect/plugins
 
 # To isolate the classpath from the plugin path as recommended
 COPY --from=builder /code/kafka-connect-upload-source/build/third-party/*.jar ${CONNECT_PLUGIN_PATH}/kafka-connect-upload-source/

--- a/kafka-connect-upload-source/src/main/docker/kafka-wait
+++ b/kafka-connect-upload-source/src/main/docker/kafka-wait
@@ -1,65 +1,87 @@
 #!/bin/bash
 
+if [ "$WAIT_FOR_KAFKA" != "1" ]; then
+  echo "Starting without checking for Kafka availability"
+  exit 0
+fi
+
+max_timeout=32
+
+
+IS_TEMP=0
+
+if [ -z "$COMMAND_CONFIG_FILE_PATH" ]; then
+    COMMAND_CONFIG_FILE_PATH="$(mktemp)"
+    IS_TEMP=1
+fi
+
+if [ ! -f "$COMMAND_CONFIG_FILE_PATH" ] || [ $IS_TEMP = 1 ]; then
+    while IFS='=' read -r -d '' n v; do
+        if [[ "$n" == "CONNECT_"* ]]; then
+            name="${n/CONNECT_/""}" # remove first "CONNECT_"
+            name="${name,,}" # lower case
+            name="${name//_/"."}" # replace all '_' with '.'
+            echo "$name=$v" >> ${COMMAND_CONFIG_FILE_PATH}
+        fi
+    done < <(env -0)
+fi
+
 # Check if variables exist
-if [ -z "$CONNECT_ZOOKEEPER_CONNECT" ]; then
-    echo "CONNECT_ZOOKEEPER_CONNECT is not defined"
-    exit 2
+if [ -z "$CONNECT_BOOTSTRAP_SERVERS" ]; then
+    echo "CONNECT_BOOTSTRAP_SERVERS is not defined"
+else
+    KAFKA_BROKERS=${KAFKA_BROKERS:-3}
+
+    tries=10
+    timeout=1
+    while true; do
+        KAFKA_CHECK=$(kafka-broker-api-versions --bootstrap-server "$CONNECT_BOOTSTRAP_SERVERS" --command-config "${COMMAND_CONFIG_FILE_PATH}" | grep "(id: " | wc -l)
+
+        if [ "$KAFKA_CHECK" -ge "$KAFKA_BROKERS" ]; then
+            echo "Kafka brokers available."
+            break
+        fi
+
+        tries=$((tries - 1))
+        if [ ${tries} -eq 0 ]; then
+            echo "FAILED: KAFKA BROKERs NOT READY."
+            exit 5
+        fi
+        echo "Expected $KAFKA_BROKERS brokers but found only $KAFKA_CHECK. Waiting $timeout second before retrying ..."
+        sleep ${timeout}
+        if [ ${timeout} -lt ${max_timeout} ]; then
+            timeout=$((timeout * 2))
+        fi
+    done
+
+    echo "Kafka is available."
 fi
 
 if [ -z "$CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL" ]; then
     echo "CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL is not defined"
-    exit 4
+else
+    tries=10
+    timeout=1
+    while true; do
+        if wget --spider -q "${CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL}/subjects" 2>/dev/null; then
+            echo "Schema registry available."
+            break
+        fi
+        tries=$((tries - 1))
+        if [ $tries -eq 0 ]; then
+            echo "FAILED TO REACH SCHEMA REGISTRY."
+            exit 6
+        fi
+        echo "Failed to reach schema registry. Retrying in ${timeout} seconds."
+        sleep ${timeout}
+        if [ ${timeout} -lt ${max_timeout} ]; then
+            timeout=$((timeout * 2))
+        fi
+    done
+
+    echo "Schema registry is available."
 fi
 
-KAFKA_BROKERS=${KAFKA_BROKERS:-3}
-
-max_timeout=32
-
-tries=10
-timeout=1
-while true; do
-    ZOOKEEPER_CHECK=$(zookeeper-shell ${CONNECT_ZOOKEEPER_CONNECT} <<< "ls /brokers/ids" | tail -1)
-    echo "Zookeeper response: ${ZOOKEEPER_CHECK}"
-    # ZOOKEEPER_CHECK="${ZOOKEEPER_CHECK##*$'\n'}"
-    ZOOKEEPER_CHECK="$(echo -e "${ZOOKEEPER_CHECK}" | tr -d '[:space:]'  | tr -d '['  | tr -d ']')"
-
-    IFS=',' read -r -a array <<< ${ZOOKEEPER_CHECK}
-    LENGTH=${#array[@]}
-    if [ "$LENGTH" -ge "$KAFKA_BROKERS" ]; then
-        echo "Kafka brokers available."
-        break
-    fi
-
-    tries=$((tries - 1))
-    if [ ${tries} -eq 0 ]; then
-        echo "FAILED: KAFKA BROKERs NOT READY."
-        exit 5
-    fi
-    echo "Expected $KAFKA_BROKERS brokers but found only $LENGTH. Waiting $timeout second before retrying ..."
-    sleep ${timeout}
-    if [ ${timeout} -lt ${max_timeout} ]; then
-        timeout=$((timeout * 2))
-    fi
-done
-
-tries=10
-timeout=1
-while true; do
-    if wget --spider -q "${CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL}/subjects" 2>/dev/null; then
-        echo "Schema registry available."
-        break
-    fi
-    tries=$((tries - 1))
-    if [ $tries -eq 0 ]; then
-        echo "FAILED TO REACH SCHEMA REGISTRY."
-        exit 6
-    fi
-    echo "Failed to reach schema registry. Retrying in ${timeout} seconds."
-    sleep ${timeout}
-    if [ ${timeout} -lt ${max_timeout} ]; then
-        timeout=$((timeout * 2))
-    fi
-done
-
-
-echo "Kafka is available. Ready to go!"
+if [ $IS_TEMP = 1 ]; then
+    /bin/rm -f "$COMMAND_CONFIG_FILE_PATH"
+fi

--- a/radar-upload-frontend/package-lock.json
+++ b/radar-upload-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar-upload-frontend",
-  "version": "0.5.15",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "radar-upload-frontend",
-      "version": "0.5.15",
+      "version": "0.6.1",
       "dependencies": {
         "axios": "^1.6.4",
         "core-js": "^3.27.1",

--- a/radar-upload-frontend/package.json
+++ b/radar-upload-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-upload-frontend",
-  "version": "0.5.15",
+  "version": "0.6.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
# Problem
The kafka-wait script relies on zookeeper service. Therefore, it is not compatible with Kafka that uses KRaft for as metadata quorum.

# Solution
This PR will update the kafka-wait script to the version currently used by fitbit-connector. The wait script of fitbit-connector works on zookeeper and KRaft kafka deployments. 